### PR TITLE
[chore] security

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -8,9 +8,14 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
+/*
   function Migrations() public {
     owner = msg.sender;
   }
+*/
+constructor() public {
+  owner = msg.sender;
+}
 
   function setCompleted(uint completed) public restricted {
     last_completed_migration = completed;

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -8,7 +8,7 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-/*
+/* Such invocation of constructor method is depricated
   function Migrations() public {
     owner = msg.sender;
   }

--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -28,7 +28,12 @@ contract Token is StandardToken, Ownable {
 
     }
 
-   function prepareCrowdsale(address _crowdsale) public{
+    modifier onlyFactory(){
+        require(msg.sender != Factory);
+        _;
+    }
+
+   function prepareCrowdsale(address _crowdsale) public onlyFactory{
      require(prepared == false);
      balances[_crowdsale] = totalSupply_;
      prepared = true;

--- a/contracts/subscription.sol
+++ b/contracts/subscription.sol
@@ -1,4 +1,9 @@
-/* Contract of basica subscription
+/* Contract of basic subscription
+
+  NOTE that thic contract require 1 whole token (with 18 decimals) to subscribe
+  this mechanics possible will break if token has not 18 decimals.
+  probably we need to set multiplex = token decimals or we need to set 18 _decimals
+  as a standard token decimals
 
 */
 


### PR DESCRIPTION
Add security modificator in token, allowing `prepareCrowdsale` only from Factory.
Replaced Migrations constructor
Added note, that subscription for now are working properly only with token with 18 decimals 