### PR TITLE
Feat/bounty

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ In the future would be possible to make any kind of deals with any user and escr
 
 ## Deal Dialog scenario (and pitfalls)
 
-![](https://github.com/MoonSHRD/Token-Factory/blob/master/images/dealdialog.jpg)
 
 Let's imagine, that we have standard window with channel info, and we have a button there "offer a deal" or  "offer a sponsorship"
 When we click that button we should see apearing of **Deal Dialog** window and chat with author should be start here.
@@ -171,7 +170,15 @@ Universale formula for setting up a advertisment price is:
 	r = exchange rate between MoonShard token (equal to USD)
 	decimals = decimals of user (chat) token.
 
+## Subscription BOUNTY
+Any subscriber can get money reward from sponsor/author
 
+`getPrize` from `Prize.sol` will get money reward to user in exchange of his chat tokens.
+
+So now, your users can be motivated to be impactivly in your channel in exchange to tokens because
+your tokens can be exchanged for a real money.
+
+It's also can be used in any cashback or bayback and also some game mechanics.
 
 ***
 Development with truffle

--- a/contracts/Prize.sol
+++ b/contracts/Prize.sol
@@ -1,7 +1,14 @@
 pragma solidity ^0.4.24;
 
 /*
-    template for crowdsale ovveride
+    This is contract **Кубышка**, which works like a standart кубышка.
+
+    Author can deploy this contract if he want to distribute prizes.
+    givePrize will add money to this contract
+    getPrize will calculate share and give money to the subscriber, and author
+    will get his tokens back.
+
+    So it's can be used in cashback or buyback mechanics
 
 */
 

--- a/contracts/Prize.sol
+++ b/contracts/Prize.sol
@@ -6,10 +6,37 @@ pragma solidity ^0.4.24;
 */
 
 import "zeppelin-solidity/contracts/ownership/Ownable.sol";
+import "zeppelin-solidity/contracts/math/SafeMath.sol";
 import "./Token.sol";
 
-contract Prize {
+contract Prize is Ownable {
 
+  Token token;
+  // sector Priz na barabane
+  uint bounty;
 
+  constructor(address _token,address _owner) public {
+    token = Token(_token);
+    owner = _owner;
+  }
+
+  function givePrize() payable public onlyOwner {
+    bounty += msg.value;
+  }
+
+// bounty hanter.. BOUNTY HANTER!
+  function getPrize(uint _value) public {
+    uint sup = token.totalSupply();
+    uint tokenshare = SafeMath.div(sup,100);
+    uint multiplex = SafeMath.div(tokenshare,_value);
+    token.transferFrom(msg.sender,owner,_value);
+    require(tokenshare >= 1);
+    uint moneyshare = SafeMath.div(bounty,100);
+    uint cashout = SafeMath.mul(moneyshare,multiplex);
+    address reciver = msg.sender;
+  //  require(reciver.call.value(cashout));
+    reciver.transfer(cashout);
+
+  }
 
 }

--- a/contracts/Prize.sol
+++ b/contracts/Prize.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.4.24;
+
+/*
+    template for crowdsale ovveride
+
+*/
+
+import "zeppelin-solidity/contracts/ownership/Ownable.sol";
+import "./Token.sol";
+
+contract Prize {
+
+
+
+}


### PR DESCRIPTION
Add bountty (cashback/buyback) mechanics for chat and channels

Now author can deploy a Prize contract for distribution real money, baybacking user tokens.

It can work in example in community chats, so now if you have community token you can:
- get subscription
- offer sponsorship deal
- get prize if author want to distribute bounty